### PR TITLE
Fix dev server start

### DIFF
--- a/project/vite.config.js
+++ b/project/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
   server: {
     port: 5179,
     strictPort: false,
-    open: true,
+    open: false,
     host: true,
     proxy: {
       '/api': 'http://localhost:5000'


### PR DESCRIPTION
## Summary
- avoid automatically opening browser on dev server start

## Testing
- `npx vite` (fails to open browser but server starts on port 5184)

------
https://chatgpt.com/codex/tasks/task_e_686bd69596a48328be3998f15a5aecb3